### PR TITLE
added <meta charset = 'utf-8'> to rChart.html template

### DIFF
--- a/inst/rChart.html
+++ b/inst/rChart.html
@@ -1,4 +1,5 @@
 <!doctype HTML>
+<meta charset = 'utf-8'>
 <html>
   <head>
     {{# assets.css }}


### PR DESCRIPTION
Since d3.v3 requires utf-8, rCharts standalone would not work correctly with d3.v3.  This has not been a problem since most of the libraries still are using d3.v2.  As these upgrade though, this will be an issue.  As far as I know, there should not be in disadvantages to changing to utf-8.
