### PR TITLE
Update makeExamples.R to fix line break in rChart2.html in create_chart()

### DIFF
--- a/R/makeExamples.R
+++ b/R/makeExamples.R
@@ -35,8 +35,7 @@ create_chart <- function(rFile){
   chart = source(rFile, local = TRUE)$value
   chart$field('srccode', rCode)
   chart$field('templates', list(
-    page = 'rChart2.h
-    tml', 
+    page = 'rChart2.html', 
     chartDiv = NULL, script =  chart$templates$script)
   )
   return(chart)


### PR DESCRIPTION
line break causes error in create_chart.  remove the line break in rChart2.html
