### PR TITLE
Show method fix

### DIFF
--- a/R/rChartsClass.R
+++ b/R/rChartsClass.R
@@ -74,7 +74,7 @@ rCharts = setRefClass('rCharts', list(params = 'list', lib = 'character',
     writeLines(.self$render(...), destfile)
   },
   show = function(static = T, ...){
-    if (getOption("knitr.in.progress")){
+    if (!is.null(getOption("knitr.in.progress")) && getOption("knitr.in.progress")){
       return(.self$print())
     }
     if (static){


### PR DESCRIPTION
I got this when creating a chart outside knit. But, I guess it's just to add `!is.null(...)`.

```
Error in if (getOption("knitr.in.progress")) { : 
  argument is of length zero
```

Otherwise, I really like this feature. I will let you know if I find some other issues.

@ramnathv minor fix to #143 
