### PR TITLE
Fix Lat/Long resolution issue for Leaflet

### DIFF
--- a/R/Leaflet.R
+++ b/R/Leaflet.R
@@ -79,7 +79,7 @@ Leaflet = setRefClass('Leaflet', contains = 'rCharts', methods = list(
     marker = paste(lapply(params$marker, toChain, obj =  'L'), collapse = '\n')
     # circle = paste(lapply(params$circle, toChain, obj =  'L'), collapse = '\n')
     circle = toChain(params$circle, obj = 'L')
-    chartParams = toJSON(params[!(names(params) %in% skip)])
+    chartParams = toJSON(params[!(names(params) %in% skip)], digits=13)
     list(
       chartParams = chartParams, 
       chartId = chartId, 


### PR DESCRIPTION
The rounding error that was previously corrected in rCharts "dev" branch for NVD3 and MORRIS also applies to Leaflet - it rounds the Lat/Long coordinates for JSON points, so that the points snap to a grid of a couple hundred feet. I edited 2 lines with "digits=13" to correct the problem.

P.S. - this is my first time using GitHub like this, so I'm not sure if this is the proper way to suggest a revision. I apologize if not.  Thanks!
