### PR TITLE
method for control over second y axis on Nvd3 lineWithFocusCharts

### DIFF
--- a/R/Nvd3.R
+++ b/R/Nvd3.R
@@ -8,7 +8,7 @@ Nvd3 <- setRefClass('Nvd3', contains = 'rCharts', methods = list(
   initialize = function(){
     callSuper(); 
     params <<- c(params, list(controls = list(),
-      chart = list(), xAxis = list(), x2Axis = list(), yAxis = list(),
+      chart = list(), xAxis = list(), x2Axis = list(), yAxis = list(), y2Axis = list(), 
       filters = list()
     ))
   },
@@ -39,6 +39,13 @@ Nvd3 <- setRefClass('Nvd3', contains = 'rCharts', methods = list(
   },
   yAxis = function(..., replace = F){
     params$yAxis <<- setSpec(params$yAxis, ..., replace = replace)
+    #if type is lineWithFocus and y2Axis not specified
+    #make it the same as yAxis
+    if(  params$type == "lineWithFocusChart" && length(params$y2Axis) == 0 ) 
+      y2Axis(..., replace = replace)
+  },
+  y2Axis = function(..., replace = F){
+    params$y2Axis <<- setSpec(params$y2Axis, ..., replace = replace)
   },
   getChartParams = function(...){
     params <<- modifyList(params, getLayer(...))
@@ -49,11 +56,12 @@ Nvd3 <- setRefClass('Nvd3', contains = 'rCharts', methods = list(
     xAxis = toChain(params$xAxis, 'chart.xAxis')
     x2Axis = toChain(params$x2Axis, 'chart.x2Axis')    
     yAxis = toChain(params$yAxis, 'chart.yAxis')
+    y2Axis = toChain(params$y2Axis, 'chart.y2Axis')
     controls_json = toJSON(params$controls)
     filters_json = toJSON(params$filters)
     controls = setNames(params$controls, NULL)
-    opts = toJSON(params[!(names(params) %in% c('data', 'chart', 'xAxis', 'x2Axis', 'yAxis', 'controls', 'filters'))])
-    list(opts = opts, xAxis = xAxis, x2Axis = x2Axis, yAxis = yAxis, data = data, 
+    opts = toJSON(params[!(names(params) %in% c('data', 'chart', 'xAxis', 'x2Axis', 'yAxis', 'y2Axis', 'controls', 'filters'))])
+    list(opts = opts, xAxis = xAxis, x2Axis = x2Axis, yAxis = yAxis, y2Axis = y2Axis, data = data, 
          chart = chart, chartId = chartId, controls = controls, 
          controls_json = controls_json, CODE = srccode, 
          filters_json = filters_json, hasFilter = (length(params$filters) > 0)

--- a/inst/libraries/nvd3/layouts/chart.html
+++ b/inst/libraries/nvd3/layouts/chart.html
@@ -41,6 +41,8 @@
         {{{ x2Axis }}}
         
         {{{ yAxis }}}
+        
+        {{{ y2Axis }}}
       
        d3.select("#" + opts.id)
         .append('svg')


### PR DESCRIPTION
Thank you for the fantastic rCharts package!

This is an implementation of styling controls over the second yAxis (yAxis2) in the Nvd3 (nChart) of type "lineWithFocusCharts", which allows changing, for example, the tick labels format on the second yAxis. I implemented it the same way you implemented xAxis2 (yAxis2 gets same parameters as yAxis if not specified) and have a code example below:

``` coffee
data <- data.frame(x = 1:100, y = round(runif(100, 0, 1), 2))
n1 <- nPlot(y ~ x, data = data, type = 'lineWithFocusChart')
n1$yAxis(tickFormat = "#!  function(y) { return d3.format('01%')(y) } !#")
n1 # same y2 axis tick labels as y1 axis (percentage)

n1$y2Axis(tickFormat = "#!  function(y) { } !#")
n1 # no y2 axis tick labels
```

I'm relatively new to GitHub and this is my first contribution to someone else's project, please forgive if I'm missing some specific conventions or etiquette about forking/pull requests.

Thank you very much again for a terrific R package.
Sebastian
