### PR TITLE
toJSON digits parameterization. See danielkrizian/rChartsDygraphs#14

### DIFF
--- a/R/rChartsClass.R
+++ b/R/rChartsClass.R
@@ -56,7 +56,11 @@ rCharts = setRefClass('rCharts', list(params = 'list', lib = 'character',
     params <<- modifyList(params, list(...))
   },
   getPayload = function(chartId){
-    list(chartParams = toJSON(params), chartId = chartId, lib = basename(lib), liburl = LIB$url)
+    if(!is.null(params$digits))
+      JSONized = toJSON(params, digits=params$digits)
+    else
+      JSONized = toJSON(params)
+    list(chartParams = JSONized, chartId = chartId, lib = basename(lib), liburl = LIB$url)
   },
   html = function(chartId = NULL){
     params$dom <<- chartId %||% params$dom


### PR DESCRIPTION
Adding ability for the user to pass `digits` parameter to toJSON

This should fix the issues with losing the decimal point precision, as documented here:
https://github.com/danielkrizian/rChartsDygraphs/issues/14#issuecomment-46632085
