### PR TITLE
Force UTF8 encoding during writeLines

### DIFF
--- a/R/gist.R
+++ b/R/gist.R
@@ -42,7 +42,9 @@ post_gist_oauth <- function(gist,
 create_gist <- function(filenames, description = "", extras = NULL, public = TRUE){
   if (!is.null(extras)) filenames <- c(filenames, extras)
   files = lapply(filenames, function(file){
-    x = list(content =  paste(readLines(file, warn = F), collapse = "\n"))
+    con <- file(file, "r", encoding = "UTF-8")
+    on.exit(close(con))
+    list(content =  paste(readLines(con, warn = F), collapse = "\n"))
   })
   names(files) = basename(filenames)
   body = list(description = description, public = public, files = files)

--- a/R/rChartsClass.R
+++ b/R/rChartsClass.R
@@ -107,7 +107,7 @@ rCharts = setRefClass('rCharts', list(params = 'list', lib = 'character',
   },
   save = function(destfile = 'index.html', ...){
     'Save chart as a standalone html page'
-    writeLines(.self$render(...), destfile)
+    write_file(.self$render(...), destfile)
   },
   show = function(mode_ = NULL, ..., extra_files = NULL){
     mode_ = getMode(mode_)
@@ -115,12 +115,9 @@ rCharts = setRefClass('rCharts', list(params = 'list', lib = 'character',
        static = {
          dir.create(temp_dir <- tempfile(pattern = 'rCharts'))
          static_ = grepl("^http", LIB$url) || is.null(viewer <- getOption('viewer'))
-         
-         tf <- file.path(temp_dir, 'index.html')
-         tfcon <- file(tf, "w", encoding = "UTF-8")
-         writeLines(.self$render(..., static = static_), tfcon)
-         close(tfcon)
-         
+         write_file(.self$render(..., static = static_),
+           tf <- file.path(temp_dir, 'index.html')
+         )
          if (!static_){
            suppressMessages(copy_dir_(LIB$url, file.path(temp_dir, LIB$name)))
            if (!is.null(extra_files)){
@@ -192,7 +189,7 @@ rCharts = setRefClass('rCharts', list(params = 'list', lib = 'character',
     # take_screenshot(htmlFile, tools::file_path_sans_ext(imgFile))
     if (!is.null(.self$srccode)){
       codeFile = file.path(tempdir(), 'code.R'); on.exit(unlink(codeFile))
-      writeLines(.self$srccode, con = codeFile)
+      write_file(.self$srccode, codeFile)
       files = c(htmlFile, codeFile)
     } else {
       files = htmlFile

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,7 +3,7 @@
 
 #' @export
 make_chart <- function(text){
-  writeLines(text, con="input.R")
+  write_file(text, "input.R")
   chart = source('input.R', local = TRUE)$value
   # chart$set(width = 700)
   # chart$setTemplate(page = 'rChart2.html')
@@ -175,6 +175,20 @@ addLayer.default <- function(...){
 #' @noRd
 read_file <- function(file, warn = F, ...){
   paste(readLines(file, warn = warn, ...), collapse = "\n")
+}
+
+#' Write lines into a file using specific encoding
+#' 
+#' @param text A character vector
+#' @param output path to text file that needs to be written
+#' @param encoding The name of the encoding to be used. See the Encoding section in \code{\link{connections}}.
+#' @param ... other parameters to be passed to \code{\link{writeLines}}
+#' @keywords internal
+#' @noRd
+write_file <- function(text, output, encoding = "UTF-8", ...){
+  con <- file(output, "w", encoding = encoding)
+  writeLines(text, con, ...)
+  close(con)
 }
 
 #' Read contents of a system file into a character string


### PR DESCRIPTION
This should fix #549 where R writes file according to default locale if not otherwise specified. It caused a problem under Windows due to lack of support for UTF8 locale and rCharts assumes everything will be written in UTF8.
