### PR TITLE
Missing quotation mark

### DIFF
--- a/inst/libraries/highcharts/config.yml
+++ b/inst/libraries/highcharts/config.yml
@@ -8,5 +8,5 @@ highcharts:
     jshead:
       - "//code.jquery.com/jquery-1.9.1.min.js"
       - "//code.highcharts.com/highcharts.js"
-      - //code.highcharts.com/highcharts-more.js"
+      - "//code.highcharts.com/highcharts-more.js"
       - "//code.highcharts.com/modules/exporting.js"


### PR DESCRIPTION
highcharts-more not loading properly because of the missing  "

i.e in deployed shiny app higcharts-more is not loaded cause the generated HTML is wrong: 
<script src="//code.highcharts.com/highcharts-more.js&quot;" type="text/javascript"></script>