### PR TITLE
Quick fix #212

### DIFF
--- a/R/Highcharts.R
+++ b/R/Highcharts.R
@@ -164,7 +164,9 @@ hPlot <- highchartPlot <- function(..., radius = 3, title = NULL, subtitle = NUL
     
     if (nrows != nrow(data)) warning("Observations with NA has been removed")
     
-    data <- data[order(data$x, data$y), ]  # order data (due to line charts)
+    if(d$type == "line"){
+        data <- data[order(data$x, data$y), ]  # order data (due to line charts)
+    }
     
     if ("bubble" %in% d$type && is.null(data$size)) stop("'size' is missing")
     


### PR DESCRIPTION
Ordering the data.frame only when the plot is a line plot allows for
bar charts ordered as the user desires.
This conflict does not seem to have a workaround when using the “group”
parameter.