### PR TITLE
Fix deprecation warning in install

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -27,7 +27,7 @@ You can install `rCharts` from `github` using the `devtools` package
 
 ```coffee
 require(devtools)
-install_github('rCharts', 'ramnathv')
+install_github('ramnathv/rCharts')
 ```
 
 ## Features


### PR DESCRIPTION
When installing rCharts as described originally:

``` R
Warning message:
Username parameter is deprecated. Please use ramnathv/rCharts 
```

This PR implements that recommendation
