### PR TITLE
Removed comments & added semicolons

### DIFF
--- a/inst/libraries/nvd3/layouts/chart.html
+++ b/inst/libraries/nvd3/layouts/chart.html
@@ -4,13 +4,11 @@
     });
     function draw{{chartId}}(){  
       var opts = {{{ opts }}},
-        data = {{{ data }}}
+        data = {{{ data }}};
   
       if(!(opts.type==="pieChart" || opts.type==="sparklinePlus" || opts.type==="bulletChart")) {
         var data = d3.nest()
           .key(function(d){
-            //return opts.group === undefined ? 'main' : d[opts.group]
-            //instead of main would think a better default is opts.x
             return opts.group === undefined ? opts.y : d[opts.group];
           })
           .entries(data);
@@ -25,7 +23,7 @@
       nv.addGraph(function() {
         var chart = nv.models[opts.type]()
           .width(opts.width)
-          .height(opts.height)
+          .height(opts.height);
           
         if (opts.type != "bulletChart"){
           chart
@@ -34,13 +32,13 @@
         }
           
          
-        {{{ chart }}}
+        {{{ chart }}};
           
-        {{{ xAxis }}}
+        {{{ xAxis }}};
 
-        {{{ x2Axis }}}
+        {{{ x2Axis }}};
         
-        {{{ yAxis }}}
+        {{{ yAxis }}};
       
        d3.select("#" + opts.id)
         .append('svg')


### PR DESCRIPTION
When the resulting HTML is minified (at least when it's done by GitHub Pages), the missing semicolons and the included comments trigger errors that prevent the chart from being displayed.
